### PR TITLE
Fix candidate validator to use experienceLevel

### DIFF
--- a/app-server/src/validators/candidate.ts
+++ b/app-server/src/validators/candidate.ts
@@ -6,7 +6,7 @@ export const createCandidateSchema = z.object({
     .min(6, "Phone number must be at least 6 characters")
     .optional(),
   location: z.string().min(2, "Location is required").optional(),
-  experience: z.string().optional(),
+  experienceLevel: z.string().optional(),
   skills: z.array(z.string()).optional(),
   languages: z
     .array(z.string().min(2, "Each language must be at least 2 characters"))


### PR DESCRIPTION
## Summary
- fix candidate validator to use `experienceLevel` instead of `experience`

## Testing
- `npm run build` *(fails: TS6059 File 'scripts/initDB.ts' is not under 'rootDir')*

------
https://chatgpt.com/codex/tasks/task_e_6863b7b240a883228efefd5f43c07773