### PR TITLE
Implement auth guard and shared footer

### DIFF
--- a/app-client/src/layouts/auth/layout.tsx
+++ b/app-client/src/layouts/auth/layout.tsx
@@ -11,6 +11,7 @@ import { RouterLink } from 'src/routes/components';
 import { Logo } from 'src/components/logo';
 
 import { AuthContent } from './content';
+import { Footer } from '../core/footer';
 import { MainSection } from '../core/main-section';
 import { LayoutSection } from '../core/layout-section';
 import { HeaderSection } from '../core/header-section';
@@ -82,7 +83,7 @@ export function AuthLayout({
     );
   };
 
-  const renderFooter = () => null;
+  const renderFooter = () => <Footer />;
 
   const renderMain = () => (
     <MainSection

--- a/app-client/src/layouts/core/footer.tsx
+++ b/app-client/src/layouts/core/footer.tsx
@@ -1,0 +1,16 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+// ----------------------------------------------------------------------
+
+export type FooterProps = React.ComponentProps<typeof Box>;
+
+export function Footer({ sx, ...other }: FooterProps) {
+  return (
+    <Box component="footer" sx={{ py: 2, textAlign: 'center', ...sx }} {...other}>
+      <Typography variant="body2" color="text.secondary">
+        © {new Date().getFullYear()} TWF
+      </Typography>
+    </Box>
+  );
+}

--- a/app-client/src/layouts/core/index.ts
+++ b/app-client/src/layouts/core/index.ts
@@ -1,3 +1,5 @@
+export * from './footer';
+
 export * from './classes';
 
 export * from './css-vars';

--- a/app-client/src/layouts/dashboard/layout.tsx
+++ b/app-client/src/layouts/dashboard/layout.tsx
@@ -9,6 +9,7 @@ import { useTheme } from '@mui/material/styles';
 
 import { _langs, _notifications } from 'src/_mock';
 
+import { Footer } from '../core/footer';
 import { NavMobile, NavDesktop } from './nav';
 import { layoutClasses } from '../core/classes';
 import { _account } from '../nav-config-account';
@@ -103,7 +104,7 @@ export function DashboardLayout({
     );
   };
 
-  const renderFooter = () => null;
+  const renderFooter = () => <Footer />;
 
   const renderMain = () => <MainSection {...slotProps?.main}>{children}</MainSection>;
 

--- a/app-client/src/routes/sections.tsx
+++ b/app-client/src/routes/sections.tsx
@@ -1,8 +1,8 @@
 import type { RouteObject } from 'react-router';
 
 import { lazy, Suspense } from 'react';
-import { Outlet } from 'react-router-dom';
 import { varAlpha } from 'minimal-shared/utils';
+import { Outlet, Navigate } from 'react-router-dom';
 
 import Box from '@mui/material/Box';
 import LinearProgress, { linearProgressClasses } from '@mui/material/LinearProgress';
@@ -40,14 +40,24 @@ const renderFallback = () => (
   </Box>
 );
 
+function AuthGuard({ children }: { children: React.ReactNode }) {
+  const isAuthenticated = Boolean(localStorage.getItem('token'));
+  if (!isAuthenticated) {
+    return <Navigate to="/sign-in" replace />;
+  }
+  return <>{children}</>;
+}
+
 export const routesSection: RouteObject[] = [
   {
     element: (
-      <DashboardLayout>
-        <Suspense fallback={renderFallback()}>
-          <Outlet />
-        </Suspense>
-      </DashboardLayout>
+      <AuthGuard>
+        <DashboardLayout>
+          <Suspense fallback={renderFallback()}>
+            <Outlet />
+          </Suspense>
+        </DashboardLayout>
+      </AuthGuard>
     ),
     children: [
       { index: true, element: <DashboardPage /> },


### PR DESCRIPTION
## Summary
- add `Footer` component under layouts/core
- expose Footer in layout exports
- display Footer in both `DashboardLayout` and `AuthLayout`
- add `AuthGuard` wrapper for dashboard routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68697c1047a48322808ec4d02fc26496