### PR TITLE
Add auth context provider

### DIFF
--- a/app-client/src/context/auth-context.tsx
+++ b/app-client/src/context/auth-context.tsx
@@ -1,0 +1,28 @@
+import { useState, useEffect, createContext } from 'react';
+
+export type AuthContextType = {
+  token: string | null;
+  setToken: React.Dispatch<React.SetStateAction<string | null>>;
+};
+
+export const AuthContext = createContext<AuthContextType>({
+  token: null,
+  setToken: () => {},
+});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('token');
+    if (stored) {
+      setToken(stored);
+    }
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/app-client/src/main.tsx
+++ b/app-client/src/main.tsx
@@ -7,6 +7,7 @@ import App from './app';
 import { client } from './graphql/client';
 import { routesSection } from './routes/sections';
 import { ErrorBoundary } from './routes/components';
+import { AuthProvider } from './context/auth-context';
 
 // ----------------------------------------------------------------------
 
@@ -27,7 +28,9 @@ const root = createRoot(document.getElementById('root')!);
 root.render(
   <StrictMode>
     <ApolloProvider client={client}>
-      <RouterProvider router={router} />
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>
     </ApolloProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add AuthContext with provider to load JWT from localStorage
- wrap router with AuthProvider in main entry

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869847f44b48322941cc2e72eba6092