### PR TITLE
Implement public JobsPage with pagination

### DIFF
--- a/app-client/src/graphql/queries.ts
+++ b/app-client/src/graphql/queries.ts
@@ -1,0 +1,14 @@
+import { gql } from '@apollo/client';
+
+export const GET_JOBS = gql`
+  query GetJobs {
+    getAllJobs {
+      id
+      title
+      description
+      location
+      type
+      createdAt
+    }
+  }
+`;

--- a/app-client/src/layouts/nav-config-dashboard.tsx
+++ b/app-client/src/layouts/nav-config-dashboard.tsx
@@ -48,4 +48,9 @@ export const navData = [
     path: '/404',
     icon: icon('ic-disabled'),
   },
+  {
+    title: 'Jobs',
+    path: '/jobs',
+    icon: icon('ic-cart'),
+  },
 ];

--- a/app-client/src/pages/jobs.tsx
+++ b/app-client/src/pages/jobs.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { useQuery } from '@apollo/client';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import Typography from '@mui/material/Typography';
+import Pagination from '@mui/material/Pagination';
+
+import { CONFIG } from 'src/config-global';
+import { GET_JOBS } from 'src/graphql/queries';
+import { DashboardContent } from 'src/layouts/dashboard';
+
+// ----------------------------------------------------------------------
+
+type Job = {
+  id: string;
+  title: string;
+  description: string;
+  location: string;
+  type: string;
+  createdAt?: string;
+};
+
+export default function Page() {
+  const { data, loading, error } = useQuery<{ getAllJobs: Job[] }>(GET_JOBS);
+
+  const [page, setPage] = useState(1);
+  const rowsPerPage = 5;
+
+  const jobs = data?.getAllJobs || [];
+  const pageCount = Math.max(1, Math.ceil(jobs.length / rowsPerPage));
+  const displayed = jobs.slice((page - 1) * rowsPerPage, page * rowsPerPage);
+
+  const handlePageChange = (_: unknown, value: number) => {
+    setPage(value);
+  };
+
+  return (
+    <>
+      <title>{`Jobs - ${CONFIG.appName}`}</title>
+      <DashboardContent>
+        <Typography variant="h4" sx={{ mb: 5 }}>
+          Jobs
+        </Typography>
+        {loading && <Typography>Loading...</Typography>}
+        {error && <Typography color="error">Error loading jobs</Typography>}
+        {displayed.map((job) => (
+          <Card key={job.id} sx={{ mb: 2, p: 2 }}>
+            <Typography variant="h6">{job.title}</Typography>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              {job.location} • {job.type}
+            </Typography>
+            <Typography variant="body2" sx={{ mt: 1 }}>
+              {job.description}
+            </Typography>
+          </Card>
+        ))}
+        {jobs.length > rowsPerPage && (
+          <Box sx={{ mt: 3, mx: 'auto' }}>
+            <Pagination count={pageCount} page={page} onChange={handlePageChange} />
+          </Box>
+        )}
+      </DashboardContent>
+    </>
+  );
+}

--- a/app-client/src/routes/sections.tsx
+++ b/app-client/src/routes/sections.tsx
@@ -18,6 +18,7 @@ export const UserPage = lazy(() => import('src/pages/user'));
 export const SignInPage = lazy(() => import('src/pages/sign-in'));
 export const SignUpPage = lazy(() => import('src/pages/sign-up'));
 export const ProductsPage = lazy(() => import('src/pages/products'));
+export const JobsPage = lazy(() => import('src/pages/jobs'));
 export const Page404 = lazy(() => import('src/pages/page-not-found'));
 
 const renderFallback = () => (
@@ -77,6 +78,16 @@ export const routesSection: RouteObject[] = [
       { path: 'sign-in', element: <SignInPage /> },
       { path: 'sign-up', element: <SignUpPage /> },
     ],
+  },
+  {
+    element: (
+      <DashboardLayout>
+        <Suspense fallback={renderFallback()}>
+          <Outlet />
+        </Suspense>
+      </DashboardLayout>
+    ),
+    children: [{ path: 'jobs', element: <JobsPage /> }],
   },
   // {
   //   path: 'sign-in',


### PR DESCRIPTION
## Summary
- add GraphQL `GET_JOBS` query
- create `JobsPage` to fetch jobs and paginate results
- expose page under `/jobs` route

## Testing
- `npx prettier -w app-client/src/graphql/queries.ts app-client/src/pages/jobs.tsx app-client/src/routes/sections.tsx`
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68698a9680108322aa7f9232b6ca8b43